### PR TITLE
fix: Using $var[$idx] instead of $var{$idx} on Parser.php

### DIFF
--- a/Spreadsheet/Excel/Writer/Parser.php
+++ b/Spreadsheet/Excel/Writer/Parser.php
@@ -1090,7 +1090,7 @@ class Spreadsheet_Excel_Writer_Parser
         $col    = 0;
         $col_ref_length = strlen($col_ref);
         for ($i = 0; $i < $col_ref_length; $i++) {
-            $col += (ord($col_ref{$i}) - ord('A') + 1) * pow(26, $expn);
+            $col += (ord($col_ref[$i]) - ord('A') + 1) * pow(26, $expn);
             $expn--;
         }
 
@@ -1112,20 +1112,20 @@ class Spreadsheet_Excel_Writer_Parser
         $formula_length = strlen($this->_formula);
         // eat up white spaces
         if ($i < $formula_length) {
-            while ($this->_formula{$i} == " ") {
+            while ($this->_formula[$i] == " ") {
                 $i++;
             }
 
             if ($i < ($formula_length - 1)) {
-                $this->_lookahead = $this->_formula{$i+1};
+                $this->_lookahead = $this->_formula[$i+1];
             }
             $token = '';
         }
 
         while ($i < $formula_length) {
-            $token .= $this->_formula{$i};
+            $token .= $this->_formula[$i];
             if ($i < ($formula_length - 1)) {
-                $this->_lookahead = $this->_formula{$i+1};
+                $this->_lookahead = $this->_formula[$i+1];
             }
             else {
                 $this->_lookahead = '';
@@ -1133,7 +1133,7 @@ class Spreadsheet_Excel_Writer_Parser
 
             if ($this->_match($token) != '') {
                 //if ($i < strlen($this->_formula) - 1) {
-                //    $this->_lookahead = $this->_formula{$i+1};
+                //    $this->_lookahead = $this->_formula[$i+1];
                 //}
                 $this->_current_char = $i + 1;
                 $this->_current_token = $token;
@@ -1141,7 +1141,7 @@ class Spreadsheet_Excel_Writer_Parser
             }
 
             if ($i < ($formula_length - 2)) {
-                $this->_lookahead = $this->_formula{$i+2};
+                $this->_lookahead = $this->_formula[$i+2];
             }
             else {
                 // if we run out of characters _lookahead becomes empty
@@ -1295,7 +1295,7 @@ class Spreadsheet_Excel_Writer_Parser
     {
         $this->_current_char = 0;
         $this->_formula      = $formula;
-        $this->_lookahead    = $formula{1};
+        $this->_lookahead    = $formula[1];
         $this->_advance();
         $this->_parse_tree   = $this->_condition();
         return true;
@@ -1651,4 +1651,3 @@ class Spreadsheet_Excel_Writer_Parser
         return $polish;
     }
 }
-


### PR DESCRIPTION
 $var{$idx} was deprecated in PHP version 7.4 and removed in PHP version 8.